### PR TITLE
Made resources/katana.yml relative to PocketMine.php

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -143,7 +143,7 @@ namespace pocketmine {
 	date_default_timezone_set("UTC");
 
 	if(!file_exists("katana.yml")){
-		$content = file_get_contents("src/pocketmine/resources/katana.yml");
+		$content = file_get_contents(__DIR__ . "/resources/katana.yml");
 		@file_put_contents("katana.yml", $content);
 	}
 


### PR DESCRIPTION
The significance is that this makes Katana.phar possible without explicitly creating katana.yml

I know that Katana is only for your own use, but actually, packing the files into a phar will make the server startup faster than loading from source.